### PR TITLE
HWM after connect warning

### DIFF
--- a/zmq.c
+++ b/zmq.c
@@ -756,6 +756,12 @@ PHP_METHOD(zmqsocket, setsockopt)
 		break;
 		
 		case ZMQ_HWM:
+		{
+			if (zend_hash_num_elements(&(intern->socket->connect)) > 0 || zend_hash_num_elements(&(intern->socket->bind)) > 0) {
+				php_error(E_WARNING, "Setting the HWM after connection has been established - option may not be appled");
+			}
+		}
+		/* No break here intentionally to fall through */
 		case ZMQ_RATE:
 		case ZMQ_RECOVERY_IVL:
 		case ZMQ_MCAST_LOOP:


### PR DESCRIPTION
Hi, added a warning to stop people do what I did with setting the HWM after the connect. Everywhere else uses exceptions, but I didn't think that stopping the whole flow was warranted for this kind of error. Happy to change it otherwise though. 
