### PR TITLE
Zeromq3 prep

### DIFF
--- a/docs/zmqdevice/setidlecallback.xml
+++ b/docs/zmqdevice/setidlecallback.xml
@@ -15,7 +15,8 @@
   </methodsynopsis>
   <para>
    Sets the idle callback function. If idle timeout is defined the idle callback function
-   shall be called if the internal poll loop times out without events.
+   shall be called if the internal poll loop times out without events. If the callback function
+   returns false or a value that evaluates to false the device is stopped.
   </para>
  </refsect1>
 

--- a/tests/029-xrepxreqdevice.phpt
+++ b/tests/029-xrepxreqdevice.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test send / recv with an XREQ and XREP device
+--SKIPIF--
+<?php 
+    require_once(dirname(__FILE__) . '/skipif.inc'); 
+?>
+--FILE--
+<?php
+
+require dirname(__FILE__) . '/zeromq_test_helper.inc';
+
+function idle_func($val)
+{
+  return false;
+}
+
+$context = new ZMQContext();
+
+$upstream = new ZMQSocket($context, ZMQ::SOCKET_XREQ);
+$upstream->bind(ZEROMQ_TEST_DSN);
+
+$downstream = new ZMQSocket($context, ZMQ::SOCKET_XREP);
+$downstream->bind(ZEROMQ_TEST_DSN2);
+
+$device = new ZMQDevice($upstream, $downstream);
+$device->setIdleTimeout(100);
+$device->setIdleCallback('idle_func', 'test');
+
+$server = new ZMQSocket($context, ZMQ::SOCKET_REP);
+$server->connect(ZEROMQ_TEST_DSN);
+
+$client = new ZMQSocket($context, ZMQ::SOCKET_REQ);
+$client->connect(ZEROMQ_TEST_DSN2);
+
+$client->sendmsg("Hello server!");
+$device->run();
+var_dump($server->recvmsg());
+
+$server->sendmsg("Hello client!");
+$device->run();
+var_dump($client->recvmsg());
+
+--EXPECT--
+string(13) "Hello server!"
+string(13) "Hello client!"


### PR DESCRIPTION
It seems labels sent in xreq/xrep devices don't count as more parts. which is more than a little confusing, and we need to pass on the fact they are labels anyway or the routing doesn't work.

So I have added the checks for label to the device code. Currently send more takes precedent if both flags where on the original message. I guess really I should check for that and send on both but currently 0mq only sends one or the other never both.
