### PR TITLE
Update zmq.c

### DIFF
--- a/zmq.c
+++ b/zmq.c
@@ -795,7 +795,7 @@ PHP_METHOD(zmqsocket, recvmulti)
 		MAKE_STD_ZVAL(msg);
 		retval = php_zmq_recv(intern, flags, msg TSRMLS_CC);
 		if (retval == 0) {
-			zval_ptr_dtor(&msg);
+			FREE_ZVAL(msg);
 			zval_dtor(return_value);
 			RETURN_FALSE;
 		}


### PR DESCRIPTION
Sometimes the "zval_ptr_dtor" in "recvMulti" make a segfault, but the FREE_ZVAL works. This might not be 

My System:
I am using PHP 5.4.6-1ubuntu1.1 with zmq (latest master) as _only_ Extension with libzmq 3.2.2.
# php -i | grep zmq

zmq
libzmq version => 3.2.2
