### PR TITLE
Allow socket streams to be polled

### DIFF
--- a/zmq_pollset.c
+++ b/zmq_pollset.c
@@ -188,11 +188,11 @@ int php_zmq_pollset_add(php_zmq_pollset *pollset, zval *entry, int events TSRMLS
 			return PHP_ZMQ_POLLSET_ERR_NO_STREAM;
 		}
 
-		if (php_stream_can_cast(stream, (PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL) & ~REPORT_ERRORS) == FAILURE) {
+		if (php_stream_can_cast(stream, (PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL | PHP_STREAM_AS_SOCKETD) & ~REPORT_ERRORS) == FAILURE) {
 			return PHP_ZMQ_POLLSET_ERR_CANNOT_CAST;
 		}
 
-		if (php_stream_cast(stream, (PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL) & ~REPORT_ERRORS, (void*)&fd, 0) == FAILURE) {
+		if (php_stream_cast(stream, (PHP_STREAM_AS_FD | PHP_STREAM_CAST_INTERNAL | PHP_STREAM_AS_SOCKETD) & ~REPORT_ERRORS, (void*)&fd, 0) == FAILURE) {
 			return PHP_ZMQ_POLLSET_ERR_CAST_FAILED;
 		}
 		


### PR DESCRIPTION
ZMQPoll::add() throws a ZMQPollException for php socket stream resources created with fsockopen() and  stream_socket_client(). The ZMQPollException is "Failed to cast the supplied stream resource." This points to line 191 in [https://github.com/mkoppanen/php-zmq/blob/master/zmq_pollset.c]. Adding PHP_STREAM_AS_SOCKETD as a cast type resolves this error.

Is there a reason why PHP_STREAM_AS_SOCKETD was not originally included here? Would this be a good fix?
