### PR TITLE
Added missing include for bool type - stdbool.h

### DIFF
--- a/php_zmq_private.h
+++ b/php_zmq_private.h
@@ -36,6 +36,7 @@
 #include "main/php_ini.h"
 
 #include <zmq.h>
+#include <stdbool.h>
 
 #ifdef PHP_WIN32
 # include "win32/php_stdint.h"


### PR DESCRIPTION
Added include for stdbool.h in php_zmq_private.h. This fixed the type error I was getting while running 'make' under FreeBSD 9.1.

/root/php-zmq/zmq_device.c:70: error: expected declaration specifiers or '...' before 'bool'
/root/php-zmq/zmq_device.c: In function 's_capture_message':
/root/php-zmq/zmq_device.c:85: error: 'more' undeclared (first use in this function)
/root/php-zmq/zmq_device.c:85: error: (Each undeclared identifier is reported only once
/root/php-zmq/zmq_device.c:85: error: for each function it appears in.)
/root/php-zmq/zmq_device.c: In function 'php_zmq_device':
/root/php-zmq/zmq_device.c:179: error: too many arguments to function 's_capture_message'
/root/php-zmq/zmq_device.c:225: error: too many arguments to function 's_capture_message'
**\* [zmq_device.lo] Error code 1
