### PR TITLE
Build php-zmq on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - ZEROMQ_VERSION=v3.2.2
     - ZEROMQ_VERSION=v3.2.3
     - ZEROMQ_VERSION=v3.2.4
+    - ZEROMQ_VERSION=v4.0.0
 before_install:
     - sudo apt-get update
     - sudo apt-get install uuid-dev

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,6 +20,11 @@ install_zeromq() {
         cd ./zeromq3-x
         git checkout tags/$zeromq_version
         ;;
+    v4*)
+        git clone https://github.com/zeromq/zeromq4-x
+        cd ./zeromq4-x
+        git checkout tags/$zeromq_version
+        ;;
     esac
     ./autogen.sh
     ./configure


### PR DESCRIPTION
### Preamble

@hintjens announced ØMQ v4 recently (see https://twitter.com/hintjens/status/381068131264761856). Soon after, I tried to build **php-zmq** against it. It failed and so I resolved to submit a PR with the fix. First though, I'd like to be confident that I, and other contributors, don't break the build.
### Build php-zmq on Travis CI

This PR introduces a Travis build configuration that builds **php-zmq** for the latest versions of PHP 5.4 and 5.5 against the following versions of ØMQ:
- 2.2.0
- 3.1.0
- 3.2.0
- 3.2.1
- 3.2.2
- 3.2.3
- 3.2.4
- 4.0.0

You can see an example of a genuine failed build here: https://travis-ci.org/phuedx/php-zmq/builds/11708039
### Breaking changes

None.
### Notes
- You'll need to enable the Travis CI service hook for the **php-zmq** repository (see https://travis-ci.org/profile)
- I've noticed that **php-zmq** doesn't build against ØMQ versions 2.2.0 through 3.2.0, which, you'll notice, can be disabled easily should you wish
- Unfortunately, it took me a few attempts to get **php-zmq** building on Travis CI, which has resulted in far-from-ideal history
