### PR TITLE
MODE_DONTWAIT replaces deprecated MODE_NOBLOCK

### DIFF
--- a/examples/non-blocking-client.php
+++ b/examples/non-blocking-client.php
@@ -15,7 +15,7 @@ echo "Trying to send message\n";
 do {
     try {
         if ($sending) {
-            if ($queue->send("This is a message", ZMQ::MODE_NOBLOCK) !== false) {
+            if ($queue->send("This is a message", ZMQ::MODE_DONTWAIT) !== false) {
                 echo "Message sent\n";
                 $sent    = true;
                 $sending = false;
@@ -35,7 +35,7 @@ echo "Trying to receive message\n";
 do {
     try {
         if ($receiving) {
-            $message = $queue->recv (ZMQ::MODE_NOBLOCK);
+            $message = $queue->recv (ZMQ::MODE_DONTWAIT);
             
             if ($message) {
                 echo "Received message: " . $message . "\n";


### PR DESCRIPTION
http://www.php.net/manual/en/class.zmq.php#zmq.constants.mode-dontwait

MODE_NOBLOCK is now a deprecated constant.
