### PR TITLE
sockopts: code condensed by moving to makros

### DIFF
--- a/options/sockopts_get.gsl
+++ b/options/sockopts_get.gsl
@@ -37,44 +37,27 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_$(NAME)
 
         case ZMQ_$(NAME):
-        {
 .        if mode = "rw" | mode = "r"
 .            gsl from "sockopts_restrict.gsl"
 .-
 .            if php_type = "int"
 .-
-            $(c_type) value;
-            value_len = sizeof($(c_type));
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_$(NAME) value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
+	        SOCKOPTS_GET_INT($(NAME), $(c_type));
 .-
 .            elsif php_type = "string"
 .-
-            $(c_type) value[$(max_length)];
-            value_len = $(max_length);
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_$(NAME) value: %s", zmq_strerror(errno));
-                return;
-            }
-.-
-.                if binary = "yes"
-            RETURN_STRINGL(value, value_len);
-.                else
-            RETURN_STRINGL(value, value_len - 1);
-.                endif /* .if binary = "yes" */
+	        SOCKOPTS_GET_STRING($(NAME), $(max_length), $(binary = 'yes'))
 .-
 .            elsif php_type = "resource"
 .-
+        {
             php_stream *stream = php_zmq_create_zmq_fd(getThis());
             if (stream) {
                 php_stream_to_zval(stream, return_value);
                 return;
             }
             RETURN_FALSE;
+        }
 .-
 .            else
 #error "Unknown type: ($type)"
@@ -85,7 +68,6 @@ PHP_METHOD(zmqsocket, getsockopt)
             return;
 .-
 .        endif /* .if mode = "rw" | mode = "r" */
-        }
         break;
 
 # endif /* ZMQ_$(NAME) */

--- a/options/sockopts_set.gsl
+++ b/options/sockopts_set.gsl
@@ -74,32 +74,18 @@ PHP_METHOD(zmqsocket, setsockopt)
 .    for option where !defined (is_alias)
 # ifdef ZMQ_$(NAME)
         case ZMQ_$(NAME):
-        {
 .-
 .        if mode = "rw" | mode = "w"
 .            gsl from "sockopts_restrict.gsl"
 .-
 .            if php_type = "int"
 .-
-            $(c_type) value = ($(c_type)) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof($(c_type))) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_$(NAME) option: %s", zmq_strerror(errno));
-                return;
-            }
+                SOCKOPTS_SET_INT($(NAME), $(c_type))
 .-
 .            elsif php_type = "string"
 .-
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING($(NAME))
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_$(NAME) option: %s", zmq_strerror(errno));
-                return;
-            }
 .-
 .            elsif php_type = "resource"
 .-
@@ -113,7 +99,6 @@ PHP_METHOD(zmqsocket, setsockopt)
 .-
 .        endif /* .if mode = "rw" | mode = "w" */
 .-
-        }
         break;
 
 # endif /* ifdef ZMQ_$(NAME) */

--- a/zmq_sockopt.c
+++ b/zmq_sockopt.c
@@ -37,6 +37,7 @@
 #include "php_zmq.h"
 #include "php_zmq_private.h"
 #include "zmq_object_access.c"
+#include "zmq_sockopts_makros.h"
 
 
 
@@ -479,97 +480,58 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_HEARTBEAT_IVL
 
         case ZMQ_HEARTBEAT_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_HEARTBEAT_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(HEARTBEAT_IVL, int);
         break;
 
 # endif /* ZMQ_HEARTBEAT_IVL */
 # ifdef ZMQ_HEARTBEAT_TTL
 
         case ZMQ_HEARTBEAT_TTL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_HEARTBEAT_TTL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(HEARTBEAT_TTL, int);
         break;
 
 # endif /* ZMQ_HEARTBEAT_TTL */
 # ifdef ZMQ_HEARTBEAT_TIMEOUT
 
         case ZMQ_HEARTBEAT_TIMEOUT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_HEARTBEAT_TIMEOUT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(HEARTBEAT_TIMEOUT, int);
         break;
 
 # endif /* ZMQ_HEARTBEAT_TIMEOUT */
 # ifdef ZMQ_USE_FD
 
         case ZMQ_USE_FD:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_USE_FD value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(USE_FD, int);
         break;
 
 # endif /* ZMQ_USE_FD */
 # ifdef ZMQ_XPUB_MANUAL
 
         case ZMQ_XPUB_MANUAL:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_XPUB_MANUAL is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_XPUB_MANUAL */
 # ifdef ZMQ_XPUB_WELCOME_MSG
 
         case ZMQ_XPUB_WELCOME_MSG:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_XPUB_WELCOME_MSG is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_XPUB_WELCOME_MSG */
 # ifdef ZMQ_STREAM_NOTIFY
 
         case ZMQ_STREAM_NOTIFY:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_STREAM_NOTIFY is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_STREAM_NOTIFY */
 # ifdef ZMQ_INVERT_MATCHING
 
         case ZMQ_INVERT_MATCHING:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB &&
             intern->socket->socket_type != ZMQ_PUB &&
@@ -578,615 +540,326 @@ PHP_METHOD(zmqsocket, getsockopt)
             return;
         }
 }
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_INVERT_MATCHING value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(INVERT_MATCHING, int);
         break;
 
 # endif /* ZMQ_INVERT_MATCHING */
 # ifdef ZMQ_XPUB_VERBOSER
 
         case ZMQ_XPUB_VERBOSER:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_XPUB_VERBOSER is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_XPUB_VERBOSER */
 # ifdef ZMQ_CONNECT_TIMEOUT
 
         case ZMQ_CONNECT_TIMEOUT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_CONNECT_TIMEOUT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(CONNECT_TIMEOUT, int);
         break;
 
 # endif /* ZMQ_CONNECT_TIMEOUT */
 # ifdef ZMQ_TCP_MAXRT
 
         case ZMQ_TCP_MAXRT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_MAXRT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_MAXRT, int);
         break;
 
 # endif /* ZMQ_TCP_MAXRT */
 # ifdef ZMQ_THREAD_SAFE
 
         case ZMQ_THREAD_SAFE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_THREAD_SAFE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(THREAD_SAFE, int);
         break;
 
 # endif /* ZMQ_THREAD_SAFE */
 # ifdef ZMQ_MULTICAST_MAXTPDU
 
         case ZMQ_MULTICAST_MAXTPDU:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MULTICAST_MAXTPDU value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MULTICAST_MAXTPDU, int);
         break;
 
 # endif /* ZMQ_MULTICAST_MAXTPDU */
 # ifdef ZMQ_VMCI_BUFFER_SIZE
 
         case ZMQ_VMCI_BUFFER_SIZE:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_VMCI_BUFFER_SIZE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(VMCI_BUFFER_SIZE, uint64_t);
         break;
 
 # endif /* ZMQ_VMCI_BUFFER_SIZE */
 # ifdef ZMQ_VMCI_BUFFER_MIN_SIZE
 
         case ZMQ_VMCI_BUFFER_MIN_SIZE:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_VMCI_BUFFER_MIN_SIZE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(VMCI_BUFFER_MIN_SIZE, uint64_t);
         break;
 
 # endif /* ZMQ_VMCI_BUFFER_MIN_SIZE */
 # ifdef ZMQ_VMCI_BUFFER_MAX_SIZE
 
         case ZMQ_VMCI_BUFFER_MAX_SIZE:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_VMCI_BUFFER_MAX_SIZE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(VMCI_BUFFER_MAX_SIZE, uint64_t);
         break;
 
 # endif /* ZMQ_VMCI_BUFFER_MAX_SIZE */
 # ifdef ZMQ_VMCI_CONNECT_TIMEOUT
 
         case ZMQ_VMCI_CONNECT_TIMEOUT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_VMCI_CONNECT_TIMEOUT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(VMCI_CONNECT_TIMEOUT, int);
         break;
 
 # endif /* ZMQ_VMCI_CONNECT_TIMEOUT */
 # ifdef ZMQ_TOS
 
         case ZMQ_TOS:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TOS value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TOS, int);
         break;
 
 # endif /* ZMQ_TOS */
 # ifdef ZMQ_ROUTER_HANDOVER
 
         case ZMQ_ROUTER_HANDOVER:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_ROUTER_HANDOVER is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_ROUTER_HANDOVER */
 # ifdef ZMQ_CONNECT_RID
 
         case ZMQ_CONNECT_RID:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_CONNECT_RID is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_CONNECT_RID */
 # ifdef ZMQ_HANDSHAKE_IVL
 
         case ZMQ_HANDSHAKE_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_HANDSHAKE_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(HANDSHAKE_IVL, int);
         break;
 
 # endif /* ZMQ_HANDSHAKE_IVL */
 # ifdef ZMQ_SOCKS_PROXY
 
         case ZMQ_SOCKS_PROXY:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SOCKS_PROXY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(SOCKS_PROXY, 255, 0)
         break;
 
 # endif /* ZMQ_SOCKS_PROXY */
 # ifdef ZMQ_XPUB_NODROP
 
         case ZMQ_XPUB_NODROP:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_XPUB_NODROP is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_XPUB_NODROP */
 # ifdef ZMQ_ROUTER_MANDATORY
 
         case ZMQ_ROUTER_MANDATORY:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_ROUTER_MANDATORY is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_ROUTER_MANDATORY */
 # ifdef ZMQ_PROBE_ROUTER
 
         case ZMQ_PROBE_ROUTER:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_PROBE_ROUTER is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_PROBE_ROUTER */
 # ifdef ZMQ_REQ_RELAXED
 
         case ZMQ_REQ_RELAXED:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_REQ_RELAXED is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_REQ_RELAXED */
 # ifdef ZMQ_REQ_CORRELATE
 
         case ZMQ_REQ_CORRELATE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_REQ_CORRELATE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_REQ_CORRELATE */
 # ifdef ZMQ_CONFLATE
 
         case ZMQ_CONFLATE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_CONFLATE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_CONFLATE */
 # ifdef ZMQ_ZAP_DOMAIN
 
         case ZMQ_ZAP_DOMAIN:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_ZAP_DOMAIN value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(ZAP_DOMAIN, 255, 0)
         break;
 
 # endif /* ZMQ_ZAP_DOMAIN */
 # ifdef ZMQ_MECHANISM
 
         case ZMQ_MECHANISM:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MECHANISM value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MECHANISM, int);
         break;
 
 # endif /* ZMQ_MECHANISM */
 # ifdef ZMQ_PLAIN_SERVER
 
         case ZMQ_PLAIN_SERVER:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_PLAIN_SERVER value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(PLAIN_SERVER, int);
         break;
 
 # endif /* ZMQ_PLAIN_SERVER */
 # ifdef ZMQ_PLAIN_USERNAME
 
         case ZMQ_PLAIN_USERNAME:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_PLAIN_USERNAME value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(PLAIN_USERNAME, 255, 0)
         break;
 
 # endif /* ZMQ_PLAIN_USERNAME */
 # ifdef ZMQ_PLAIN_PASSWORD
 
         case ZMQ_PLAIN_PASSWORD:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_PLAIN_PASSWORD value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(PLAIN_PASSWORD, 255, 0)
         break;
 
 # endif /* ZMQ_PLAIN_PASSWORD */
 # ifdef ZMQ_CURVE_SERVER
 
         case ZMQ_CURVE_SERVER:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_CURVE_SERVER value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(CURVE_SERVER, int);
         break;
 
 # endif /* ZMQ_CURVE_SERVER */
 # ifdef ZMQ_CURVE_PUBLICKEY
 
         case ZMQ_CURVE_PUBLICKEY:
-        {
-            char value[32];
-            value_len = 32;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_CURVE_PUBLICKEY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len);
-        }
+	        SOCKOPTS_GET_STRING(CURVE_PUBLICKEY, 32, 1)
         break;
 
 # endif /* ZMQ_CURVE_PUBLICKEY */
 # ifdef ZMQ_CURVE_SECRETKEY
 
         case ZMQ_CURVE_SECRETKEY:
-        {
-            char value[32];
-            value_len = 32;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_CURVE_SECRETKEY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len);
-        }
+	        SOCKOPTS_GET_STRING(CURVE_SECRETKEY, 32, 1)
         break;
 
 # endif /* ZMQ_CURVE_SECRETKEY */
 # ifdef ZMQ_CURVE_SERVERKEY
 
         case ZMQ_CURVE_SERVERKEY:
-        {
-            char value[32];
-            value_len = 32;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_CURVE_SERVERKEY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len);
-        }
+	        SOCKOPTS_GET_STRING(CURVE_SERVERKEY, 32, 1)
         break;
 
 # endif /* ZMQ_CURVE_SERVERKEY */
 # ifdef ZMQ_GSSAPI_SERVER
 
         case ZMQ_GSSAPI_SERVER:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_GSSAPI_SERVER value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(GSSAPI_SERVER, int);
         break;
 
 # endif /* ZMQ_GSSAPI_SERVER */
 # ifdef ZMQ_GSSAPI_PLAINTEXT
 
         case ZMQ_GSSAPI_PLAINTEXT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_GSSAPI_PLAINTEXT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(GSSAPI_PLAINTEXT, int);
         break;
 
 # endif /* ZMQ_GSSAPI_PLAINTEXT */
 # ifdef ZMQ_GSSAPI_PRINCIPAL
 
         case ZMQ_GSSAPI_PRINCIPAL:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_GSSAPI_PRINCIPAL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(GSSAPI_PRINCIPAL, 255, 0)
         break;
 
 # endif /* ZMQ_GSSAPI_PRINCIPAL */
 # ifdef ZMQ_GSSAPI_SERVICE_PRINCIPAL
 
         case ZMQ_GSSAPI_SERVICE_PRINCIPAL:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_GSSAPI_SERVICE_PRINCIPAL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(GSSAPI_SERVICE_PRINCIPAL, 255, 0)
         break;
 
 # endif /* ZMQ_GSSAPI_SERVICE_PRINCIPAL */
 # ifdef ZMQ_IPV6
 
         case ZMQ_IPV6:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IPV6 value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(IPV6, int);
         break;
 
 # endif /* ZMQ_IPV6 */
 # ifdef ZMQ_IMMEDIATE
 
         case ZMQ_IMMEDIATE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IMMEDIATE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(IMMEDIATE, int);
         break;
 
 # endif /* ZMQ_IMMEDIATE */
 # ifdef ZMQ_ROUTER_RAW
 
         case ZMQ_ROUTER_RAW:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_ROUTER_RAW is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_ROUTER_RAW */
 # ifdef ZMQ_IPV4ONLY
 
         case ZMQ_IPV4ONLY:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IPV4ONLY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(IPV4ONLY, int);
         break;
 
 # endif /* ZMQ_IPV4ONLY */
 # ifdef ZMQ_TYPE
 
         case ZMQ_TYPE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TYPE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TYPE, int);
         break;
 
 # endif /* ZMQ_TYPE */
 # ifdef ZMQ_SNDHWM
 
         case ZMQ_SNDHWM:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDHWM value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDHWM, int);
         break;
 
 # endif /* ZMQ_SNDHWM */
 # ifdef ZMQ_RCVHWM
 
         case ZMQ_RCVHWM:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVHWM value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVHWM, int);
         break;
 
 # endif /* ZMQ_RCVHWM */
 # ifdef ZMQ_AFFINITY
 
         case ZMQ_AFFINITY:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_AFFINITY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(AFFINITY, uint64_t);
         break;
 
 # endif /* ZMQ_AFFINITY */
 # ifdef ZMQ_SUBSCRIBE
 
         case ZMQ_SUBSCRIBE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_SUBSCRIBE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_SUBSCRIBE */
 # ifdef ZMQ_UNSUBSCRIBE
 
         case ZMQ_UNSUBSCRIBE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_UNSUBSCRIBE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_UNSUBSCRIBE */
 # ifdef ZMQ_IDENTITY
 
         case ZMQ_IDENTITY:
-        {
 {
         if (intern->socket->socket_type != ZMQ_REQ &&
             intern->socket->socket_type != ZMQ_REP &&
@@ -1196,290 +869,142 @@ PHP_METHOD(zmqsocket, getsockopt)
             return;
         }
 }
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IDENTITY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len);
-        }
+	        SOCKOPTS_GET_STRING(IDENTITY, 255, 1)
         break;
 
 # endif /* ZMQ_IDENTITY */
 # ifdef ZMQ_RATE
 
         case ZMQ_RATE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RATE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RATE, int);
         break;
 
 # endif /* ZMQ_RATE */
 # ifdef ZMQ_RECOVERY_IVL
 
         case ZMQ_RECOVERY_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECOVERY_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECOVERY_IVL, int);
         break;
 
 # endif /* ZMQ_RECOVERY_IVL */
 # ifdef ZMQ_SNDBUF
 
         case ZMQ_SNDBUF:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDBUF value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDBUF, int);
         break;
 
 # endif /* ZMQ_SNDBUF */
 # ifdef ZMQ_RCVBUF
 
         case ZMQ_RCVBUF:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVBUF value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVBUF, int);
         break;
 
 # endif /* ZMQ_RCVBUF */
 # ifdef ZMQ_LINGER
 
         case ZMQ_LINGER:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_LINGER value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(LINGER, int);
         break;
 
 # endif /* ZMQ_LINGER */
 # ifdef ZMQ_RECONNECT_IVL
 
         case ZMQ_RECONNECT_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECONNECT_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECONNECT_IVL, int);
         break;
 
 # endif /* ZMQ_RECONNECT_IVL */
 # ifdef ZMQ_RECONNECT_IVL_MAX
 
         case ZMQ_RECONNECT_IVL_MAX:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECONNECT_IVL_MAX value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECONNECT_IVL_MAX, int);
         break;
 
 # endif /* ZMQ_RECONNECT_IVL_MAX */
 # ifdef ZMQ_BACKLOG
 
         case ZMQ_BACKLOG:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_BACKLOG value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(BACKLOG, int);
         break;
 
 # endif /* ZMQ_BACKLOG */
 # ifdef ZMQ_MAXMSGSIZE
 
         case ZMQ_MAXMSGSIZE:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MAXMSGSIZE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MAXMSGSIZE, int64_t);
         break;
 
 # endif /* ZMQ_MAXMSGSIZE */
 # ifdef ZMQ_MULTICAST_HOPS
 
         case ZMQ_MULTICAST_HOPS:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MULTICAST_HOPS value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MULTICAST_HOPS, int);
         break;
 
 # endif /* ZMQ_MULTICAST_HOPS */
 # ifdef ZMQ_RCVTIMEO
 
         case ZMQ_RCVTIMEO:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVTIMEO value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVTIMEO, int);
         break;
 
 # endif /* ZMQ_RCVTIMEO */
 # ifdef ZMQ_SNDTIMEO
 
         case ZMQ_SNDTIMEO:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDTIMEO value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDTIMEO, int);
         break;
 
 # endif /* ZMQ_SNDTIMEO */
 # ifdef ZMQ_XPUB_VERBOSE
 
         case ZMQ_XPUB_VERBOSE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_XPUB_VERBOSE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_XPUB_VERBOSE */
 # ifdef ZMQ_TCP_KEEPALIVE
 
         case ZMQ_TCP_KEEPALIVE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE */
 # ifdef ZMQ_TCP_KEEPALIVE_IDLE
 
         case ZMQ_TCP_KEEPALIVE_IDLE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE_IDLE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE_IDLE, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE_IDLE */
 # ifdef ZMQ_TCP_KEEPALIVE_CNT
 
         case ZMQ_TCP_KEEPALIVE_CNT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE_CNT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE_CNT, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE_CNT */
 # ifdef ZMQ_TCP_KEEPALIVE_INTVL
 
         case ZMQ_TCP_KEEPALIVE_INTVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE_INTVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE_INTVL, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE_INTVL */
 # ifdef ZMQ_TCP_ACCEPT_FILTER
 
         case ZMQ_TCP_ACCEPT_FILTER:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_TCP_ACCEPT_FILTER is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_TCP_ACCEPT_FILTER */
 # ifdef ZMQ_RCVMORE
 
         case ZMQ_RCVMORE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVMORE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVMORE, int);
         break;
 
 # endif /* ZMQ_RCVMORE */
@@ -1500,31 +1025,14 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_EVENTS
 
         case ZMQ_EVENTS:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_EVENTS value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(EVENTS, int);
         break;
 
 # endif /* ZMQ_EVENTS */
 # ifdef ZMQ_LAST_ENDPOINT
 
         case ZMQ_LAST_ENDPOINT:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_LAST_ENDPOINT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(LAST_ENDPOINT, 255, 0)
         break;
 
 # endif /* ZMQ_LAST_ENDPOINT */
@@ -1541,112 +1049,65 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_ROUTER_RAW
 
         case ZMQ_ROUTER_RAW:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_ROUTER_RAW is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_ROUTER_RAW */
 # ifdef ZMQ_IPV4ONLY
 
         case ZMQ_IPV4ONLY:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IPV4ONLY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(IPV4ONLY, int);
         break;
 
 # endif /* ZMQ_IPV4ONLY */
 # ifdef ZMQ_TYPE
 
         case ZMQ_TYPE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TYPE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TYPE, int);
         break;
 
 # endif /* ZMQ_TYPE */
 # ifdef ZMQ_SNDHWM
 
         case ZMQ_SNDHWM:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDHWM value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDHWM, int);
         break;
 
 # endif /* ZMQ_SNDHWM */
 # ifdef ZMQ_RCVHWM
 
         case ZMQ_RCVHWM:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVHWM value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVHWM, int);
         break;
 
 # endif /* ZMQ_RCVHWM */
 # ifdef ZMQ_AFFINITY
 
         case ZMQ_AFFINITY:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_AFFINITY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(AFFINITY, uint64_t);
         break;
 
 # endif /* ZMQ_AFFINITY */
 # ifdef ZMQ_SUBSCRIBE
 
         case ZMQ_SUBSCRIBE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_SUBSCRIBE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_SUBSCRIBE */
 # ifdef ZMQ_UNSUBSCRIBE
 
         case ZMQ_UNSUBSCRIBE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_UNSUBSCRIBE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_UNSUBSCRIBE */
 # ifdef ZMQ_IDENTITY
 
         case ZMQ_IDENTITY:
-        {
 {
         if (intern->socket->socket_type != ZMQ_REQ &&
             intern->socket->socket_type != ZMQ_REP &&
@@ -1656,290 +1117,142 @@ PHP_METHOD(zmqsocket, getsockopt)
             return;
         }
 }
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IDENTITY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len);
-        }
+	        SOCKOPTS_GET_STRING(IDENTITY, 255, 1)
         break;
 
 # endif /* ZMQ_IDENTITY */
 # ifdef ZMQ_RATE
 
         case ZMQ_RATE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RATE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RATE, int);
         break;
 
 # endif /* ZMQ_RATE */
 # ifdef ZMQ_RECOVERY_IVL
 
         case ZMQ_RECOVERY_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECOVERY_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECOVERY_IVL, int);
         break;
 
 # endif /* ZMQ_RECOVERY_IVL */
 # ifdef ZMQ_SNDBUF
 
         case ZMQ_SNDBUF:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDBUF value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDBUF, int);
         break;
 
 # endif /* ZMQ_SNDBUF */
 # ifdef ZMQ_RCVBUF
 
         case ZMQ_RCVBUF:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVBUF value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVBUF, int);
         break;
 
 # endif /* ZMQ_RCVBUF */
 # ifdef ZMQ_LINGER
 
         case ZMQ_LINGER:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_LINGER value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(LINGER, int);
         break;
 
 # endif /* ZMQ_LINGER */
 # ifdef ZMQ_RECONNECT_IVL
 
         case ZMQ_RECONNECT_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECONNECT_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECONNECT_IVL, int);
         break;
 
 # endif /* ZMQ_RECONNECT_IVL */
 # ifdef ZMQ_RECONNECT_IVL_MAX
 
         case ZMQ_RECONNECT_IVL_MAX:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECONNECT_IVL_MAX value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECONNECT_IVL_MAX, int);
         break;
 
 # endif /* ZMQ_RECONNECT_IVL_MAX */
 # ifdef ZMQ_BACKLOG
 
         case ZMQ_BACKLOG:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_BACKLOG value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(BACKLOG, int);
         break;
 
 # endif /* ZMQ_BACKLOG */
 # ifdef ZMQ_MAXMSGSIZE
 
         case ZMQ_MAXMSGSIZE:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MAXMSGSIZE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MAXMSGSIZE, int64_t);
         break;
 
 # endif /* ZMQ_MAXMSGSIZE */
 # ifdef ZMQ_MULTICAST_HOPS
 
         case ZMQ_MULTICAST_HOPS:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MULTICAST_HOPS value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MULTICAST_HOPS, int);
         break;
 
 # endif /* ZMQ_MULTICAST_HOPS */
 # ifdef ZMQ_RCVTIMEO
 
         case ZMQ_RCVTIMEO:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVTIMEO value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVTIMEO, int);
         break;
 
 # endif /* ZMQ_RCVTIMEO */
 # ifdef ZMQ_SNDTIMEO
 
         case ZMQ_SNDTIMEO:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDTIMEO value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDTIMEO, int);
         break;
 
 # endif /* ZMQ_SNDTIMEO */
 # ifdef ZMQ_XPUB_VERBOSE
 
         case ZMQ_XPUB_VERBOSE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_XPUB_VERBOSE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_XPUB_VERBOSE */
 # ifdef ZMQ_TCP_KEEPALIVE
 
         case ZMQ_TCP_KEEPALIVE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE */
 # ifdef ZMQ_TCP_KEEPALIVE_IDLE
 
         case ZMQ_TCP_KEEPALIVE_IDLE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE_IDLE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE_IDLE, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE_IDLE */
 # ifdef ZMQ_TCP_KEEPALIVE_CNT
 
         case ZMQ_TCP_KEEPALIVE_CNT:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE_CNT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE_CNT, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE_CNT */
 # ifdef ZMQ_TCP_KEEPALIVE_INTVL
 
         case ZMQ_TCP_KEEPALIVE_INTVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TCP_KEEPALIVE_INTVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TCP_KEEPALIVE_INTVL, int);
         break;
 
 # endif /* ZMQ_TCP_KEEPALIVE_INTVL */
 # ifdef ZMQ_TCP_ACCEPT_FILTER
 
         case ZMQ_TCP_ACCEPT_FILTER:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_TCP_ACCEPT_FILTER is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_TCP_ACCEPT_FILTER */
 # ifdef ZMQ_RCVMORE
 
         case ZMQ_RCVMORE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVMORE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVMORE, int);
         break;
 
 # endif /* ZMQ_RCVMORE */
@@ -1960,31 +1273,14 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_EVENTS
 
         case ZMQ_EVENTS:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_EVENTS value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(EVENTS, int);
         break;
 
 # endif /* ZMQ_EVENTS */
 # ifdef ZMQ_LAST_ENDPOINT
 
         case ZMQ_LAST_ENDPOINT:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_LAST_ENDPOINT value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len - 1);
-        }
+	        SOCKOPTS_GET_STRING(LAST_ENDPOINT, 255, 0)
         break;
 
 # endif /* ZMQ_LAST_ENDPOINT */
@@ -2001,291 +1297,142 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_HWM
 
         case ZMQ_HWM:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_HWM value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(HWM, uint64_t);
         break;
 
 # endif /* ZMQ_HWM */
 # ifdef ZMQ_SWAP
 
         case ZMQ_SWAP:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SWAP value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SWAP, int64_t);
         break;
 
 # endif /* ZMQ_SWAP */
 # ifdef ZMQ_AFFINITY
 
         case ZMQ_AFFINITY:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_AFFINITY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(AFFINITY, uint64_t);
         break;
 
 # endif /* ZMQ_AFFINITY */
 # ifdef ZMQ_IDENTITY
 
         case ZMQ_IDENTITY:
-        {
-            char value[255];
-            value_len = 255;
-
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_IDENTITY value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_STRINGL(value, value_len);
-        }
+	        SOCKOPTS_GET_STRING(IDENTITY, 255, 1)
         break;
 
 # endif /* ZMQ_IDENTITY */
 # ifdef ZMQ_RATE
 
         case ZMQ_RATE:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RATE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RATE, int64_t);
         break;
 
 # endif /* ZMQ_RATE */
 # ifdef ZMQ_RECOVERY_IVL
 
         case ZMQ_RECOVERY_IVL:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECOVERY_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECOVERY_IVL, int64_t);
         break;
 
 # endif /* ZMQ_RECOVERY_IVL */
 # ifdef ZMQ_RECOVERY_IVL_MSEC
 
         case ZMQ_RECOVERY_IVL_MSEC:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECOVERY_IVL_MSEC value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECOVERY_IVL_MSEC, int64_t);
         break;
 
 # endif /* ZMQ_RECOVERY_IVL_MSEC */
 # ifdef ZMQ_MCAST_LOOP
 
         case ZMQ_MCAST_LOOP:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_MCAST_LOOP value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(MCAST_LOOP, int64_t);
         break;
 
 # endif /* ZMQ_MCAST_LOOP */
 # ifdef ZMQ_RCVTIMEO
 
         case ZMQ_RCVTIMEO:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVTIMEO value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVTIMEO, int);
         break;
 
 # endif /* ZMQ_RCVTIMEO */
 # ifdef ZMQ_SNDTIMEO
 
         case ZMQ_SNDTIMEO:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDTIMEO value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDTIMEO, int);
         break;
 
 # endif /* ZMQ_SNDTIMEO */
 # ifdef ZMQ_SNDBUF
 
         case ZMQ_SNDBUF:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_SNDBUF value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(SNDBUF, uint64_t);
         break;
 
 # endif /* ZMQ_SNDBUF */
 # ifdef ZMQ_RCVBUF
 
         case ZMQ_RCVBUF:
-        {
-            uint64_t value;
-            value_len = sizeof(uint64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVBUF value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVBUF, uint64_t);
         break;
 
 # endif /* ZMQ_RCVBUF */
 # ifdef ZMQ_LINGER
 
         case ZMQ_LINGER:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_LINGER value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(LINGER, int);
         break;
 
 # endif /* ZMQ_LINGER */
 # ifdef ZMQ_RECONNECT_IVL
 
         case ZMQ_RECONNECT_IVL:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECONNECT_IVL value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECONNECT_IVL, int);
         break;
 
 # endif /* ZMQ_RECONNECT_IVL */
 # ifdef ZMQ_RECONNECT_IVL_MAX
 
         case ZMQ_RECONNECT_IVL_MAX:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RECONNECT_IVL_MAX value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RECONNECT_IVL_MAX, int);
         break;
 
 # endif /* ZMQ_RECONNECT_IVL_MAX */
 # ifdef ZMQ_BACKLOG
 
         case ZMQ_BACKLOG:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_BACKLOG value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(BACKLOG, int);
         break;
 
 # endif /* ZMQ_BACKLOG */
 # ifdef ZMQ_SUBSCRIBE
 
         case ZMQ_SUBSCRIBE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_SUBSCRIBE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_SUBSCRIBE */
 # ifdef ZMQ_UNSUBSCRIBE
 
         case ZMQ_UNSUBSCRIBE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Getting ZMQ::SOCKOPT_UNSUBSCRIBE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ZMQ_UNSUBSCRIBE */
 # ifdef ZMQ_TYPE
 
         case ZMQ_TYPE:
-        {
-            int value;
-            value_len = sizeof(int);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_TYPE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(TYPE, int);
         break;
 
 # endif /* ZMQ_TYPE */
 # ifdef ZMQ_RCVMORE
 
         case ZMQ_RCVMORE:
-        {
-            int64_t value;
-            value_len = sizeof(int64_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_RCVMORE value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(RCVMORE, int64_t);
         break;
 
 # endif /* ZMQ_RCVMORE */
@@ -2306,15 +1453,7 @@ PHP_METHOD(zmqsocket, getsockopt)
 # ifdef ZMQ_EVENTS
 
         case ZMQ_EVENTS:
-        {
-            uint32_t value;
-            value_len = sizeof(uint32_t);
-            if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to get the option ZMQ::SOCKOPT_EVENTS value: %s", zmq_strerror(errno));
-                return;
-            }
-            RETURN_LONG(value);
-        }
+	        SOCKOPTS_GET_INT(EVENTS, uint32_t);
         break;
 
 # endif /* ZMQ_EVENTS */
@@ -2396,127 +1535,74 @@ PHP_METHOD(zmqsocket, setsockopt)
 
 # ifdef ZMQ_HEARTBEAT_IVL
         case ZMQ_HEARTBEAT_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_HEARTBEAT_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(HEARTBEAT_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_HEARTBEAT_IVL */
 
 # ifdef ZMQ_HEARTBEAT_TTL
         case ZMQ_HEARTBEAT_TTL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_HEARTBEAT_TTL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(HEARTBEAT_TTL, int)
         break;
 
 # endif /* ifdef ZMQ_HEARTBEAT_TTL */
 
 # ifdef ZMQ_HEARTBEAT_TIMEOUT
         case ZMQ_HEARTBEAT_TIMEOUT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_HEARTBEAT_TIMEOUT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(HEARTBEAT_TIMEOUT, int)
         break;
 
 # endif /* ifdef ZMQ_HEARTBEAT_TIMEOUT */
 
 # ifdef ZMQ_USE_FD
         case ZMQ_USE_FD:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_USE_FD option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(USE_FD, int)
         break;
 
 # endif /* ifdef ZMQ_USE_FD */
 
 # ifdef ZMQ_XPUB_MANUAL
         case ZMQ_XPUB_MANUAL:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_XPUB_MANUAL is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_XPUB_MANUAL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(XPUB_MANUAL, int)
         break;
 
 # endif /* ifdef ZMQ_XPUB_MANUAL */
 
 # ifdef ZMQ_XPUB_WELCOME_MSG
         case ZMQ_XPUB_WELCOME_MSG:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_XPUB_WELCOME_MSG is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(XPUB_WELCOME_MSG)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_XPUB_WELCOME_MSG option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_XPUB_WELCOME_MSG */
 
 # ifdef ZMQ_STREAM_NOTIFY
         case ZMQ_STREAM_NOTIFY:
-        {
 {
         if (intern->socket->socket_type != ZMQ_STREAM) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_STREAM_NOTIFY is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_STREAM_NOTIFY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(STREAM_NOTIFY, int)
         break;
 
 # endif /* ifdef ZMQ_STREAM_NOTIFY */
 
 # ifdef ZMQ_INVERT_MATCHING
         case ZMQ_INVERT_MATCHING:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB &&
             intern->socket->socket_type != ZMQ_PUB &&
@@ -2525,182 +1611,103 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_INVERT_MATCHING option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(INVERT_MATCHING, int)
         break;
 
 # endif /* ifdef ZMQ_INVERT_MATCHING */
 
 # ifdef ZMQ_XPUB_VERBOSER
         case ZMQ_XPUB_VERBOSER:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_XPUB_VERBOSER is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_XPUB_VERBOSER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(XPUB_VERBOSER, int)
         break;
 
 # endif /* ifdef ZMQ_XPUB_VERBOSER */
 
 # ifdef ZMQ_CONNECT_TIMEOUT
         case ZMQ_CONNECT_TIMEOUT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CONNECT_TIMEOUT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(CONNECT_TIMEOUT, int)
         break;
 
 # endif /* ifdef ZMQ_CONNECT_TIMEOUT */
 
 # ifdef ZMQ_TCP_MAXRT
         case ZMQ_TCP_MAXRT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_MAXRT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_MAXRT, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_MAXRT */
 
 # ifdef ZMQ_THREAD_SAFE
         case ZMQ_THREAD_SAFE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_THREAD_SAFE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_THREAD_SAFE */
 
 # ifdef ZMQ_MULTICAST_MAXTPDU
         case ZMQ_MULTICAST_MAXTPDU:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_MULTICAST_MAXTPDU option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(MULTICAST_MAXTPDU, int)
         break;
 
 # endif /* ifdef ZMQ_MULTICAST_MAXTPDU */
 
 # ifdef ZMQ_VMCI_BUFFER_SIZE
         case ZMQ_VMCI_BUFFER_SIZE:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_VMCI_BUFFER_SIZE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(VMCI_BUFFER_SIZE, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_VMCI_BUFFER_SIZE */
 
 # ifdef ZMQ_VMCI_BUFFER_MIN_SIZE
         case ZMQ_VMCI_BUFFER_MIN_SIZE:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_VMCI_BUFFER_MIN_SIZE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(VMCI_BUFFER_MIN_SIZE, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_VMCI_BUFFER_MIN_SIZE */
 
 # ifdef ZMQ_VMCI_BUFFER_MAX_SIZE
         case ZMQ_VMCI_BUFFER_MAX_SIZE:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_VMCI_BUFFER_MAX_SIZE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(VMCI_BUFFER_MAX_SIZE, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_VMCI_BUFFER_MAX_SIZE */
 
 # ifdef ZMQ_VMCI_CONNECT_TIMEOUT
         case ZMQ_VMCI_CONNECT_TIMEOUT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_VMCI_CONNECT_TIMEOUT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(VMCI_CONNECT_TIMEOUT, int)
         break;
 
 # endif /* ifdef ZMQ_VMCI_CONNECT_TIMEOUT */
 
 # ifdef ZMQ_TOS
         case ZMQ_TOS:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TOS option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TOS, int)
         break;
 
 # endif /* ifdef ZMQ_TOS */
 
 # ifdef ZMQ_ROUTER_HANDOVER
         case ZMQ_ROUTER_HANDOVER:
-        {
 {
         if (intern->socket->socket_type != ZMQ_ROUTER) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_ROUTER_HANDOVER is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_ROUTER_HANDOVER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(ROUTER_HANDOVER, int)
         break;
 
 # endif /* ifdef ZMQ_ROUTER_HANDOVER */
 
 # ifdef ZMQ_CONNECT_RID
         case ZMQ_CONNECT_RID:
-        {
 {
         if (intern->socket->socket_type != ZMQ_ROUTER &&
             intern->socket->socket_type != ZMQ_STREAM) {
@@ -2708,56 +1715,29 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(CONNECT_RID)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CONNECT_RID option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_CONNECT_RID */
 
 # ifdef ZMQ_HANDSHAKE_IVL
         case ZMQ_HANDSHAKE_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_HANDSHAKE_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(HANDSHAKE_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_HANDSHAKE_IVL */
 
 # ifdef ZMQ_SOCKS_PROXY
         case ZMQ_SOCKS_PROXY:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(SOCKS_PROXY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SOCKS_PROXY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_SOCKS_PROXY */
 
 # ifdef ZMQ_XPUB_NODROP
         case ZMQ_XPUB_NODROP:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB &&
             intern->socket->socket_type != ZMQ_PUB) {
@@ -2765,40 +1745,26 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_XPUB_NODROP option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(XPUB_NODROP, int)
         break;
 
 # endif /* ifdef ZMQ_XPUB_NODROP */
 
 # ifdef ZMQ_ROUTER_MANDATORY
         case ZMQ_ROUTER_MANDATORY:
-        {
 {
         if (intern->socket->socket_type != ZMQ_ROUTER) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_ROUTER_MANDATORY is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_ROUTER_MANDATORY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(ROUTER_MANDATORY, int)
         break;
 
 # endif /* ifdef ZMQ_ROUTER_MANDATORY */
 
 # ifdef ZMQ_PROBE_ROUTER
         case ZMQ_PROBE_ROUTER:
-        {
 {
         if (intern->socket->socket_type != ZMQ_ROUTER &&
             intern->socket->socket_type != ZMQ_DEALER &&
@@ -2807,60 +1773,39 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_PROBE_ROUTER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(PROBE_ROUTER, int)
         break;
 
 # endif /* ifdef ZMQ_PROBE_ROUTER */
 
 # ifdef ZMQ_REQ_RELAXED
         case ZMQ_REQ_RELAXED:
-        {
 {
         if (intern->socket->socket_type != ZMQ_REQ) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_REQ_RELAXED is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_REQ_RELAXED option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(REQ_RELAXED, int)
         break;
 
 # endif /* ifdef ZMQ_REQ_RELAXED */
 
 # ifdef ZMQ_REQ_CORRELATE
         case ZMQ_REQ_CORRELATE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_REQ) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_REQ_CORRELATE is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_REQ_CORRELATE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(REQ_CORRELATE, int)
         break;
 
 # endif /* ifdef ZMQ_REQ_CORRELATE */
 
 # ifdef ZMQ_CONFLATE
         case ZMQ_CONFLATE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_PUSH &&
             intern->socket->socket_type != ZMQ_PULL &&
@@ -2871,392 +1816,204 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CONFLATE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(CONFLATE, int)
         break;
 
 # endif /* ifdef ZMQ_CONFLATE */
 
 # ifdef ZMQ_ZAP_DOMAIN
         case ZMQ_ZAP_DOMAIN:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(ZAP_DOMAIN)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_ZAP_DOMAIN option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_ZAP_DOMAIN */
 
 # ifdef ZMQ_MECHANISM
         case ZMQ_MECHANISM:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_MECHANISM is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_MECHANISM */
 
 # ifdef ZMQ_PLAIN_SERVER
         case ZMQ_PLAIN_SERVER:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_PLAIN_SERVER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(PLAIN_SERVER, int)
         break;
 
 # endif /* ifdef ZMQ_PLAIN_SERVER */
 
 # ifdef ZMQ_PLAIN_USERNAME
         case ZMQ_PLAIN_USERNAME:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(PLAIN_USERNAME)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_PLAIN_USERNAME option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_PLAIN_USERNAME */
 
 # ifdef ZMQ_PLAIN_PASSWORD
         case ZMQ_PLAIN_PASSWORD:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(PLAIN_PASSWORD)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_PLAIN_PASSWORD option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_PLAIN_PASSWORD */
 
 # ifdef ZMQ_CURVE_SERVER
         case ZMQ_CURVE_SERVER:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CURVE_SERVER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(CURVE_SERVER, int)
         break;
 
 # endif /* ifdef ZMQ_CURVE_SERVER */
 
 # ifdef ZMQ_CURVE_PUBLICKEY
         case ZMQ_CURVE_PUBLICKEY:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(CURVE_PUBLICKEY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CURVE_PUBLICKEY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_CURVE_PUBLICKEY */
 
 # ifdef ZMQ_CURVE_SECRETKEY
         case ZMQ_CURVE_SECRETKEY:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(CURVE_SECRETKEY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CURVE_SECRETKEY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_CURVE_SECRETKEY */
 
 # ifdef ZMQ_CURVE_SERVERKEY
         case ZMQ_CURVE_SERVERKEY:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(CURVE_SERVERKEY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_CURVE_SERVERKEY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_CURVE_SERVERKEY */
 
 # ifdef ZMQ_GSSAPI_SERVER
         case ZMQ_GSSAPI_SERVER:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_GSSAPI_SERVER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(GSSAPI_SERVER, int)
         break;
 
 # endif /* ifdef ZMQ_GSSAPI_SERVER */
 
 # ifdef ZMQ_GSSAPI_PLAINTEXT
         case ZMQ_GSSAPI_PLAINTEXT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_GSSAPI_PLAINTEXT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(GSSAPI_PLAINTEXT, int)
         break;
 
 # endif /* ifdef ZMQ_GSSAPI_PLAINTEXT */
 
 # ifdef ZMQ_GSSAPI_PRINCIPAL
         case ZMQ_GSSAPI_PRINCIPAL:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(GSSAPI_PRINCIPAL)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_GSSAPI_PRINCIPAL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_GSSAPI_PRINCIPAL */
 
 # ifdef ZMQ_GSSAPI_SERVICE_PRINCIPAL
         case ZMQ_GSSAPI_SERVICE_PRINCIPAL:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(GSSAPI_SERVICE_PRINCIPAL)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_GSSAPI_SERVICE_PRINCIPAL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_GSSAPI_SERVICE_PRINCIPAL */
 
 # ifdef ZMQ_IPV6
         case ZMQ_IPV6:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IPV6 option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(IPV6, int)
         break;
 
 # endif /* ifdef ZMQ_IPV6 */
 
 # ifdef ZMQ_IMMEDIATE
         case ZMQ_IMMEDIATE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IMMEDIATE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(IMMEDIATE, int)
         break;
 
 # endif /* ifdef ZMQ_IMMEDIATE */
 
 # ifdef ZMQ_ROUTER_RAW
         case ZMQ_ROUTER_RAW:
-        {
 {
         if (intern->socket->socket_type != ZMQ_ROUTER) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_ROUTER_RAW is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_ROUTER_RAW option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(ROUTER_RAW, int)
         break;
 
 # endif /* ifdef ZMQ_ROUTER_RAW */
 
 # ifdef ZMQ_IPV4ONLY
         case ZMQ_IPV4ONLY:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IPV4ONLY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(IPV4ONLY, int)
         break;
 
 # endif /* ifdef ZMQ_IPV4ONLY */
 
 # ifdef ZMQ_TYPE
         case ZMQ_TYPE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_TYPE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_TYPE */
 
 # ifdef ZMQ_SNDHWM
         case ZMQ_SNDHWM:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDHWM option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDHWM, int)
         break;
 
 # endif /* ifdef ZMQ_SNDHWM */
 
 # ifdef ZMQ_RCVHWM
         case ZMQ_RCVHWM:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVHWM option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVHWM, int)
         break;
 
 # endif /* ifdef ZMQ_RCVHWM */
 
 # ifdef ZMQ_AFFINITY
         case ZMQ_AFFINITY:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_AFFINITY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(AFFINITY, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_AFFINITY */
 
 # ifdef ZMQ_SUBSCRIBE
         case ZMQ_SUBSCRIBE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_SUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_SUBSCRIBE is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(SUBSCRIBE)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SUBSCRIBE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_SUBSCRIBE */
 
 # ifdef ZMQ_UNSUBSCRIBE
         case ZMQ_UNSUBSCRIBE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_SUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_UNSUBSCRIBE is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(UNSUBSCRIBE)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_UNSUBSCRIBE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_UNSUBSCRIBE */
 
 # ifdef ZMQ_IDENTITY
         case ZMQ_IDENTITY:
-        {
 {
         if (intern->socket->socket_type != ZMQ_REQ &&
             intern->socket->socket_type != ZMQ_REP &&
@@ -3266,319 +2023,173 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(IDENTITY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IDENTITY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_IDENTITY */
 
 # ifdef ZMQ_RATE
         case ZMQ_RATE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RATE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RATE, int)
         break;
 
 # endif /* ifdef ZMQ_RATE */
 
 # ifdef ZMQ_RECOVERY_IVL
         case ZMQ_RECOVERY_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECOVERY_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECOVERY_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_RECOVERY_IVL */
 
 # ifdef ZMQ_SNDBUF
         case ZMQ_SNDBUF:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDBUF option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDBUF, int)
         break;
 
 # endif /* ifdef ZMQ_SNDBUF */
 
 # ifdef ZMQ_RCVBUF
         case ZMQ_RCVBUF:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVBUF option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVBUF, int)
         break;
 
 # endif /* ifdef ZMQ_RCVBUF */
 
 # ifdef ZMQ_LINGER
         case ZMQ_LINGER:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_LINGER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(LINGER, int)
         break;
 
 # endif /* ifdef ZMQ_LINGER */
 
 # ifdef ZMQ_RECONNECT_IVL
         case ZMQ_RECONNECT_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECONNECT_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECONNECT_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_RECONNECT_IVL */
 
 # ifdef ZMQ_RECONNECT_IVL_MAX
         case ZMQ_RECONNECT_IVL_MAX:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECONNECT_IVL_MAX option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECONNECT_IVL_MAX, int)
         break;
 
 # endif /* ifdef ZMQ_RECONNECT_IVL_MAX */
 
 # ifdef ZMQ_BACKLOG
         case ZMQ_BACKLOG:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_BACKLOG option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(BACKLOG, int)
         break;
 
 # endif /* ifdef ZMQ_BACKLOG */
 
 # ifdef ZMQ_MAXMSGSIZE
         case ZMQ_MAXMSGSIZE:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_MAXMSGSIZE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(MAXMSGSIZE, int64_t)
         break;
 
 # endif /* ifdef ZMQ_MAXMSGSIZE */
 
 # ifdef ZMQ_MULTICAST_HOPS
         case ZMQ_MULTICAST_HOPS:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_MULTICAST_HOPS option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(MULTICAST_HOPS, int)
         break;
 
 # endif /* ifdef ZMQ_MULTICAST_HOPS */
 
 # ifdef ZMQ_RCVTIMEO
         case ZMQ_RCVTIMEO:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVTIMEO option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVTIMEO, int)
         break;
 
 # endif /* ifdef ZMQ_RCVTIMEO */
 
 # ifdef ZMQ_SNDTIMEO
         case ZMQ_SNDTIMEO:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDTIMEO option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDTIMEO, int)
         break;
 
 # endif /* ifdef ZMQ_SNDTIMEO */
 
 # ifdef ZMQ_XPUB_VERBOSE
         case ZMQ_XPUB_VERBOSE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_XPUB_VERBOSE is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_XPUB_VERBOSE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(XPUB_VERBOSE, int)
         break;
 
 # endif /* ifdef ZMQ_XPUB_VERBOSE */
 
 # ifdef ZMQ_TCP_KEEPALIVE
         case ZMQ_TCP_KEEPALIVE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE */
 
 # ifdef ZMQ_TCP_KEEPALIVE_IDLE
         case ZMQ_TCP_KEEPALIVE_IDLE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE_IDLE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE_IDLE, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE_IDLE */
 
 # ifdef ZMQ_TCP_KEEPALIVE_CNT
         case ZMQ_TCP_KEEPALIVE_CNT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE_CNT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE_CNT, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE_CNT */
 
 # ifdef ZMQ_TCP_KEEPALIVE_INTVL
         case ZMQ_TCP_KEEPALIVE_INTVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE_INTVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE_INTVL, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE_INTVL */
 
 # ifdef ZMQ_TCP_ACCEPT_FILTER
         case ZMQ_TCP_ACCEPT_FILTER:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(TCP_ACCEPT_FILTER)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_ACCEPT_FILTER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_TCP_ACCEPT_FILTER */
 
 # ifdef ZMQ_RCVMORE
         case ZMQ_RCVMORE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_RCVMORE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_RCVMORE */
 
 # ifdef ZMQ_FD
         case ZMQ_FD:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_FD is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_FD */
 
 # ifdef ZMQ_EVENTS
         case ZMQ_EVENTS:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_EVENTS is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_EVENTS */
 
 # ifdef ZMQ_LAST_ENDPOINT
         case ZMQ_LAST_ENDPOINT:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_LAST_ENDPOINT is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_LAST_ENDPOINT */
@@ -3596,141 +2207,83 @@ PHP_METHOD(zmqsocket, setsockopt)
 
 # ifdef ZMQ_ROUTER_RAW
         case ZMQ_ROUTER_RAW:
-        {
 {
         if (intern->socket->socket_type != ZMQ_ROUTER) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_ROUTER_RAW is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_ROUTER_RAW option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(ROUTER_RAW, int)
         break;
 
 # endif /* ifdef ZMQ_ROUTER_RAW */
 
 # ifdef ZMQ_IPV4ONLY
         case ZMQ_IPV4ONLY:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IPV4ONLY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(IPV4ONLY, int)
         break;
 
 # endif /* ifdef ZMQ_IPV4ONLY */
 
 # ifdef ZMQ_TYPE
         case ZMQ_TYPE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_TYPE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_TYPE */
 
 # ifdef ZMQ_SNDHWM
         case ZMQ_SNDHWM:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDHWM option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDHWM, int)
         break;
 
 # endif /* ifdef ZMQ_SNDHWM */
 
 # ifdef ZMQ_RCVHWM
         case ZMQ_RCVHWM:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVHWM option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVHWM, int)
         break;
 
 # endif /* ifdef ZMQ_RCVHWM */
 
 # ifdef ZMQ_AFFINITY
         case ZMQ_AFFINITY:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_AFFINITY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(AFFINITY, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_AFFINITY */
 
 # ifdef ZMQ_SUBSCRIBE
         case ZMQ_SUBSCRIBE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_SUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_SUBSCRIBE is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(SUBSCRIBE)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SUBSCRIBE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_SUBSCRIBE */
 
 # ifdef ZMQ_UNSUBSCRIBE
         case ZMQ_UNSUBSCRIBE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_SUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_UNSUBSCRIBE is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(UNSUBSCRIBE)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_UNSUBSCRIBE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_UNSUBSCRIBE */
 
 # ifdef ZMQ_IDENTITY
         case ZMQ_IDENTITY:
-        {
 {
         if (intern->socket->socket_type != ZMQ_REQ &&
             intern->socket->socket_type != ZMQ_REP &&
@@ -3740,319 +2293,173 @@ PHP_METHOD(zmqsocket, setsockopt)
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(IDENTITY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IDENTITY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_IDENTITY */
 
 # ifdef ZMQ_RATE
         case ZMQ_RATE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RATE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RATE, int)
         break;
 
 # endif /* ifdef ZMQ_RATE */
 
 # ifdef ZMQ_RECOVERY_IVL
         case ZMQ_RECOVERY_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECOVERY_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECOVERY_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_RECOVERY_IVL */
 
 # ifdef ZMQ_SNDBUF
         case ZMQ_SNDBUF:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDBUF option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDBUF, int)
         break;
 
 # endif /* ifdef ZMQ_SNDBUF */
 
 # ifdef ZMQ_RCVBUF
         case ZMQ_RCVBUF:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVBUF option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVBUF, int)
         break;
 
 # endif /* ifdef ZMQ_RCVBUF */
 
 # ifdef ZMQ_LINGER
         case ZMQ_LINGER:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_LINGER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(LINGER, int)
         break;
 
 # endif /* ifdef ZMQ_LINGER */
 
 # ifdef ZMQ_RECONNECT_IVL
         case ZMQ_RECONNECT_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECONNECT_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECONNECT_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_RECONNECT_IVL */
 
 # ifdef ZMQ_RECONNECT_IVL_MAX
         case ZMQ_RECONNECT_IVL_MAX:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECONNECT_IVL_MAX option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECONNECT_IVL_MAX, int)
         break;
 
 # endif /* ifdef ZMQ_RECONNECT_IVL_MAX */
 
 # ifdef ZMQ_BACKLOG
         case ZMQ_BACKLOG:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_BACKLOG option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(BACKLOG, int)
         break;
 
 # endif /* ifdef ZMQ_BACKLOG */
 
 # ifdef ZMQ_MAXMSGSIZE
         case ZMQ_MAXMSGSIZE:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_MAXMSGSIZE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(MAXMSGSIZE, int64_t)
         break;
 
 # endif /* ifdef ZMQ_MAXMSGSIZE */
 
 # ifdef ZMQ_MULTICAST_HOPS
         case ZMQ_MULTICAST_HOPS:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_MULTICAST_HOPS option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(MULTICAST_HOPS, int)
         break;
 
 # endif /* ifdef ZMQ_MULTICAST_HOPS */
 
 # ifdef ZMQ_RCVTIMEO
         case ZMQ_RCVTIMEO:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVTIMEO option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVTIMEO, int)
         break;
 
 # endif /* ifdef ZMQ_RCVTIMEO */
 
 # ifdef ZMQ_SNDTIMEO
         case ZMQ_SNDTIMEO:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDTIMEO option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDTIMEO, int)
         break;
 
 # endif /* ifdef ZMQ_SNDTIMEO */
 
 # ifdef ZMQ_XPUB_VERBOSE
         case ZMQ_XPUB_VERBOSE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_XPUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_XPUB_VERBOSE is not valid for this socket type", errno);
             return;
         }
 }
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_XPUB_VERBOSE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(XPUB_VERBOSE, int)
         break;
 
 # endif /* ifdef ZMQ_XPUB_VERBOSE */
 
 # ifdef ZMQ_TCP_KEEPALIVE
         case ZMQ_TCP_KEEPALIVE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE */
 
 # ifdef ZMQ_TCP_KEEPALIVE_IDLE
         case ZMQ_TCP_KEEPALIVE_IDLE:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE_IDLE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE_IDLE, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE_IDLE */
 
 # ifdef ZMQ_TCP_KEEPALIVE_CNT
         case ZMQ_TCP_KEEPALIVE_CNT:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE_CNT option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE_CNT, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE_CNT */
 
 # ifdef ZMQ_TCP_KEEPALIVE_INTVL
         case ZMQ_TCP_KEEPALIVE_INTVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_KEEPALIVE_INTVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(TCP_KEEPALIVE_INTVL, int)
         break;
 
 # endif /* ifdef ZMQ_TCP_KEEPALIVE_INTVL */
 
 # ifdef ZMQ_TCP_ACCEPT_FILTER
         case ZMQ_TCP_ACCEPT_FILTER:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(TCP_ACCEPT_FILTER)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_TCP_ACCEPT_FILTER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_TCP_ACCEPT_FILTER */
 
 # ifdef ZMQ_RCVMORE
         case ZMQ_RCVMORE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_RCVMORE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_RCVMORE */
 
 # ifdef ZMQ_FD
         case ZMQ_FD:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_FD is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_FD */
 
 # ifdef ZMQ_EVENTS
         case ZMQ_EVENTS:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_EVENTS is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_EVENTS */
 
 # ifdef ZMQ_LAST_ENDPOINT
         case ZMQ_LAST_ENDPOINT:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_LAST_ENDPOINT is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_LAST_ENDPOINT */
@@ -4070,316 +2477,173 @@ PHP_METHOD(zmqsocket, setsockopt)
 
 # ifdef ZMQ_HWM
         case ZMQ_HWM:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_HWM option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(HWM, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_HWM */
 
 # ifdef ZMQ_SWAP
         case ZMQ_SWAP:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SWAP option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SWAP, int64_t)
         break;
 
 # endif /* ifdef ZMQ_SWAP */
 
 # ifdef ZMQ_AFFINITY
         case ZMQ_AFFINITY:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_AFFINITY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(AFFINITY, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_AFFINITY */
 
 # ifdef ZMQ_IDENTITY
         case ZMQ_IDENTITY:
-        {
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(IDENTITY)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_IDENTITY option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_IDENTITY */
 
 # ifdef ZMQ_RATE
         case ZMQ_RATE:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RATE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RATE, int64_t)
         break;
 
 # endif /* ifdef ZMQ_RATE */
 
 # ifdef ZMQ_RECOVERY_IVL
         case ZMQ_RECOVERY_IVL:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECOVERY_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECOVERY_IVL, int64_t)
         break;
 
 # endif /* ifdef ZMQ_RECOVERY_IVL */
 
 # ifdef ZMQ_RECOVERY_IVL_MSEC
         case ZMQ_RECOVERY_IVL_MSEC:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECOVERY_IVL_MSEC option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECOVERY_IVL_MSEC, int64_t)
         break;
 
 # endif /* ifdef ZMQ_RECOVERY_IVL_MSEC */
 
 # ifdef ZMQ_MCAST_LOOP
         case ZMQ_MCAST_LOOP:
-        {
-            int64_t value = (int64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_MCAST_LOOP option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(MCAST_LOOP, int64_t)
         break;
 
 # endif /* ifdef ZMQ_MCAST_LOOP */
 
 # ifdef ZMQ_RCVTIMEO
         case ZMQ_RCVTIMEO:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVTIMEO option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVTIMEO, int)
         break;
 
 # endif /* ifdef ZMQ_RCVTIMEO */
 
 # ifdef ZMQ_SNDTIMEO
         case ZMQ_SNDTIMEO:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDTIMEO option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDTIMEO, int)
         break;
 
 # endif /* ifdef ZMQ_SNDTIMEO */
 
 # ifdef ZMQ_SNDBUF
         case ZMQ_SNDBUF:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SNDBUF option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(SNDBUF, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_SNDBUF */
 
 # ifdef ZMQ_RCVBUF
         case ZMQ_RCVBUF:
-        {
-            uint64_t value = (uint64_t) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(uint64_t)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RCVBUF option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RCVBUF, uint64_t)
         break;
 
 # endif /* ifdef ZMQ_RCVBUF */
 
 # ifdef ZMQ_LINGER
         case ZMQ_LINGER:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_LINGER option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(LINGER, int)
         break;
 
 # endif /* ifdef ZMQ_LINGER */
 
 # ifdef ZMQ_RECONNECT_IVL
         case ZMQ_RECONNECT_IVL:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECONNECT_IVL option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECONNECT_IVL, int)
         break;
 
 # endif /* ifdef ZMQ_RECONNECT_IVL */
 
 # ifdef ZMQ_RECONNECT_IVL_MAX
         case ZMQ_RECONNECT_IVL_MAX:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_RECONNECT_IVL_MAX option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(RECONNECT_IVL_MAX, int)
         break;
 
 # endif /* ifdef ZMQ_RECONNECT_IVL_MAX */
 
 # ifdef ZMQ_BACKLOG
         case ZMQ_BACKLOG:
-        {
-            int value = (int) zval_get_long(zv);
-
-            if (zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int)) != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_BACKLOG option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
+                SOCKOPTS_SET_INT(BACKLOG, int)
         break;
 
 # endif /* ifdef ZMQ_BACKLOG */
 
 # ifdef ZMQ_SUBSCRIBE
         case ZMQ_SUBSCRIBE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_SUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_SUBSCRIBE is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(SUBSCRIBE)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_SUBSCRIBE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_SUBSCRIBE */
 
 # ifdef ZMQ_UNSUBSCRIBE
         case ZMQ_UNSUBSCRIBE:
-        {
 {
         if (intern->socket->socket_type != ZMQ_SUB) {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "ZMQ::SOCKOPT_UNSUBSCRIBE is not valid for this socket type", errno);
             return;
         }
 }
-            int rc;
-            zend_string *str = zval_get_string(zv);
+                SOCKOPTS_SET_STRING(UNSUBSCRIBE)
 
-            rc = zmq_setsockopt(intern->socket->z_socket, key, str->val, str->len);
-            zend_string_release(str);
-
-            if (rc != 0) {
-                zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno, "Failed to set socket ZMQ::SOCKOPT_UNSUBSCRIBE option: %s", zmq_strerror(errno));
-                return;
-            }
-        }
         break;
 
 # endif /* ifdef ZMQ_UNSUBSCRIBE */
 
 # ifdef ZMQ_TYPE
         case ZMQ_TYPE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_TYPE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_TYPE */
 
 # ifdef ZMQ_RCVMORE
         case ZMQ_RCVMORE:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_RCVMORE is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_RCVMORE */
 
 # ifdef ZMQ_FD
         case ZMQ_FD:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_FD is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_FD */
 
 # ifdef ZMQ_EVENTS
         case ZMQ_EVENTS:
-        {
             zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "Setting ZMQ::SOCKOPT_EVENTS is not supported", PHP_ZMQ_INTERNAL_ERROR);
             return;
-        }
         break;
 
 # endif /* ifdef ZMQ_EVENTS */


### PR DESCRIPTION
The code is autogenerated by the *.gsl scripts. In order to
minimize the c code now parts of the gsl code generation is
moved to new makro definitions in zmq_sockopts_makros.h

This reduces the overall lines of the file and makes it more
readable for future additions of flags.