### PR TITLE
Fix build warnings

### DIFF
--- a/zmq.c
+++ b/zmq.c
@@ -207,7 +207,7 @@ php_zmq_context *php_zmq_context_get(zend_long io_threads, zend_bool is_persiste
 
 	if (is_persistent) {
 		zend_resource *le_p = NULL;
-		plist_key = strpprintf(0, "zmq_context=[%ld]", io_threads);
+		plist_key = strpprintf(0, "zmq_context=[%ld]", (long)io_threads);
 
 		if ((le_p = zend_hash_find_ptr(&EG(persistent_list), plist_key)) != NULL) {
 			if (le_p->type == php_zmq_context_list_entry()) {
@@ -523,7 +523,7 @@ php_zmq_socket *php_zmq_socket_new(php_zmq_context *context, zend_long type, zen
 static
 zend_string *php_zmq_socket_plist_key(zend_long type, zend_string *persistent_id, zend_bool use_shared_ctx)
 {
-	return strpprintf(0, "zmq_socket:[%ld]-[%s]-[%d]", type, persistent_id->val, use_shared_ctx);
+	return strpprintf(0, "zmq_socket:[%ld]-[%s]-[%d]", (long)type, persistent_id->val, use_shared_ctx);
 }
 
 static

--- a/zmq_fd_stream.c
+++ b/zmq_fd_stream.c
@@ -43,13 +43,23 @@ typedef struct _php_zmq_stream_container {
 } php_zmq_stream_container;
 
 static
-size_t php_zmq_fd_read(php_stream *stream, char *buf, size_t count)
+#if PHP_VERSION_ID < 70400
+size_t
+#else
+ssize_t
+#endif
+php_zmq_fd_read(php_stream *stream, char *buf, size_t count)
 {
 	return 0;
 }
 
 static
-size_t php_zmq_fd_write(php_stream *stream, const char *buf, size_t count)
+#if PHP_VERSION_ID < 70400
+size_t
+#else
+ssize_t
+#endif
+php_zmq_fd_write(php_stream *stream, const char *buf, size_t count)
 {
 	return 0;
 }

--- a/zmq_helpers.c
+++ b/zmq_helpers.c
@@ -63,7 +63,11 @@ char *php_zmq_printable_func (zend_fcall_info *fci, zend_fcall_info_cache *fci_c
 	char *buffer = NULL;
 
 	if (fci->object) {
+#if PHP_VERSION_ID < 70000
 		spprintf (&buffer, 0, "%s::%s", fci->object->ce->name->val, fci_cache->function_handler->common.function_name);
+#else
+		spprintf (&buffer, 0, "%s::%s", fci->object->ce->name->val, ZSTR_VAL(fci_cache->function_handler->common.function_name));
+#endif
 	} else {
 		if (Z_TYPE (fci->function_name) == IS_OBJECT) {
 			spprintf (&buffer, 0, "%s", Z_OBJCE (fci->function_name)->name->val);

--- a/zmq_pollset.c
+++ b/zmq_pollset.c
@@ -169,7 +169,7 @@ static
 zend_string *s_create_key(zval *entry)
 {
 	if (Z_TYPE_P(entry) == IS_RESOURCE) {
-		return strpprintf(0, "r:%ld", Z_RES_P(entry)->handle);
+		return strpprintf(0, "r:%d", Z_RES_P(entry)->handle);
 	}
 	else {
 		zend_string *hash = php_spl_object_hash(entry);
@@ -222,7 +222,7 @@ size_t php_zmq_pollset_num_items(php_zmq_pollset *set)
 zend_string *php_zmq_pollset_add(php_zmq_pollset *set, zval *entry, int events, int *error) 
 {
 	zend_string *key;
-	size_t num_items, index;
+	size_t index;
 	zmq_pollitem_t item;
 
 	*error = 0;
@@ -233,7 +233,6 @@ zend_string *php_zmq_pollset_add(php_zmq_pollset *set, zval *entry, int events, 
 		return key;
 	}
 
-	num_items = php_zmq_pollset_num_items(set);
 	memset(&item, 0, sizeof(zmq_pollitem_t));
 
 	if (Z_TYPE_P(entry) == IS_RESOURCE) {

--- a/zmq_sockopt.c
+++ b/zmq_sockopt.c
@@ -1038,7 +1038,7 @@ PHP_METHOD(zmqsocket, getsockopt)
 # endif /* ZMQ_LAST_ENDPOINT */
 
         default:
-            zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), PHP_ZMQ_INTERNAL_ERROR, "Unknown option key %ld", key);
+            zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), PHP_ZMQ_INTERNAL_ERROR, "Unknown option key %ld", (long)key);
             return;
     }
 
@@ -2196,7 +2196,7 @@ PHP_METHOD(zmqsocket, setsockopt)
 
 
         default:
-            zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), PHP_ZMQ_INTERNAL_ERROR, "Unknown option key %ld", key);
+            zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), PHP_ZMQ_INTERNAL_ERROR, "Unknown option key %ld", (long)key);
             return;
     }
     ZMQ_RETURN_THIS;


### PR DESCRIPTION
- since 7.4, The read and write operations of php_stream_ops now return ssize_t,
  with negative values indicating an error.
- since 7.0, function_name is a zend_string
- handle is an "int"