### PR TITLE
fix for PHP 8.0.0beta2

### DIFF
--- a/zmq.c
+++ b/zmq.c
@@ -621,7 +621,9 @@ zend_bool php_zmq_connect_callback(zval *socket, zend_fcall_info *fci, zend_fcal
 	fci->params         = params;
 	fci->param_count    = 2;
 	fci->retval         = &retval;
+#if PHP_VERSION_ID < 80000
 	fci->no_separation  = 1;
+#endif
 
 	if (zend_call_function(fci, fci_cache) == FAILURE) {
 		if (!EG(exception)) {

--- a/zmq_device.c
+++ b/zmq_device.c
@@ -53,7 +53,9 @@ zend_bool s_invoke_device_cb (php_zmq_device_cb_t *cb, uint64_t current_ts)
 	cb->fci.param_count = 1;
 
 	/* Call the cb */
+#if PHP_VERSION_ID < 80000
 	cb->fci.no_separation  = 1;
+#endif
 	cb->fci.retval         = &fc_retval;
 
 	if (zend_call_function(&(cb->fci), &(cb->fci_cache)) == FAILURE) {


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
  s. The zend_fcall_info no_separation flag has been removed, and separation is
      never allowed. If you wish to pass (or allow passing) arguments by
      reference, explicitly create those arguments as references using
      ZEND_MAKE_REF. This removal also affects call_user_function_ex(), which
      should be replaced by call_user_function().
```
