### PR TITLE
fix 8.2 deprecations

### DIFF
--- a/tests/007-addremovepoll.phpt
+++ b/tests/007-addremovepoll.phpt
@@ -16,14 +16,14 @@ $z = create_client();
 $socket_server = stream_socket_server("tcp://127.0.0.1:5858", $errno, $errstr);
 
 if (!$socket_server) {
-	echo "Failed to create socket server: ${errstr}" . PHP_EOL;
+	echo "Failed to create socket server: {$errstr}" . PHP_EOL;
 	exit (1);
 }
 
 $socket_client = stream_socket_client("tcp://127.0.0.1:5858", $errno, $errstr);
 
 if (!$socket_client) {
-	echo "Failed to create socket client: ${errstr}" . PHP_EOL;
+	echo "Failed to create socket client: {$errstr}" . PHP_EOL;
 	exit (1);
 }
 

--- a/tests/036-device.phpt
+++ b/tests/036-device.phpt
@@ -17,11 +17,11 @@ class CbStateData
 	protected $_name;
 
 	public function __construct ($name) {
-	  $this->name = $name;
+	  $this->_name = $name;
 	}
 
 	public function getName () {
-	  return $this->name;
+	  return $this->_name;
 	}
 
 	public function increment ()
@@ -58,7 +58,7 @@ $orig_cb = function ($user_data) use (&$last_called, $device) {
 				$time_elapsed = (proper_microtime () - $last_called) + 1;
 
 				if ($time_elapsed < $device->getTimerTimeout ()) {
-					echo "Called too early, only ${time_elapsed}ms elapsed, expected {$device->getTimerTimeout ()}" . PHP_EOL;
+					echo "Called too early, only {$time_elapsed}ms elapsed, expected {$device->getTimerTimeout ()}" . PHP_EOL;
 				}
 
 				$device->setTimerTimeout ($device->getTimerTimeout () + 50);

--- a/tests/037-device-deprecated.phpt
+++ b/tests/037-device-deprecated.phpt
@@ -14,7 +14,7 @@ $device = new ZMQDevice($s1, $ctx->getSocket(ZMQ::SOCKET_PUB));
 
 // Setup callback and user data for callback
 $device->setIdleTimeout (100);
-$device->setIdleCallback (function ($user_data) { echo "Called: ${user_data}" . PHP_EOL; return false; }, "test");
+$device->setIdleCallback (function ($user_data) { echo "Called: {$user_data}" . PHP_EOL; return false; }, "test");
 
 // Run first time
 $device->run ();

--- a/tests/048-pollsetitems.phpt
+++ b/tests/048-pollsetitems.phpt
@@ -19,14 +19,14 @@ $poll = new ZMQPoll();
 $socket_server = stream_socket_server("tcp://127.0.0.1:5858", $errno, $errstr);
 
 if (!$socket_server) {
-	echo "Failed to create socket server: ${errstr}" . PHP_EOL;
+	echo "Failed to create socket server: {$errstr}" . PHP_EOL;
 	exit (1);
 }
 
 $socket_client = stream_socket_client("tcp://127.0.0.1:5858", $errno, $errstr);
 
 if (!$socket_client) {
-	echo "Failed to create socket client: ${errstr}" . PHP_EOL;
+	echo "Failed to create socket client: {$errstr}" . PHP_EOL;
 	exit (1);
 }
 


### PR DESCRIPTION
```
TEST 7/65 [tests/007-addremovepoll.phpt]
========DIFF========
001+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /work/GIT/pecl-and-ext/zmq/tests/007-addremovepoll.php on line 14
002+ 
003+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /work/GIT/pecl-and-ext/zmq/tests/007-addremovepoll.php on line 21
     string(34) "o:%s"
     string(3) "r:%d"
     int(2)
--
========DONE========
FAIL Test adding / removing items [tests/007-addremovepoll.phpt] 

TEST 36/65 [tests/036-device.phpt]
========DIFF========
001+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /work/GIT/pecl-and-ext/zmq/tests/036-device.php on line 54
002+ 
003+ Deprecated: Creation of dynamic property CbStateData::$name is deprecated in /work/GIT/pecl-and-ext/zmq/tests/036-device.php on line 13
     Triggered for 100ms timeout
     timer function called 1 times
     Triggered for 150ms timeout
--
========DONE========
FAIL Test device callbacks [tests/036-device.phpt] 

TEST 37/65 [tests/037-device-deprecated.phpt]
========DIFF========
001+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /work/GIT/pecl-and-ext/zmq/tests/037-device-deprecated.php on line 10
002+ 
     Deprecated: ZMQDevice::setidlecallback(): The signature for setIdleCallback has changed, please update your code in %s on line %d
     Called: test
     OK
========DONE========
FAIL Test device deprecated args [tests/037-device-deprecated.phpt] 

TEST 48/65 [tests/048-pollsetitems.phpt]
========DIFF========
001+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /work/GIT/pecl-and-ext/zmq/tests/048-pollsetitems.php on line 12
002+ 
003+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /work/GIT/pecl-and-ext/zmq/tests/048-pollsetitems.php on line 19
     array(3) {
       ["o:%s"]=>
       object(ZMQSocket)#%d (%d) {
--
========DONE========
FAIL Test pollset items [tests/048-pollsetitems.phpt]


```