### PR TITLE
fix missing win32/php_stdint.h when building for php 8.x on Windows, add Windows build instructions

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -38,3 +38,19 @@ line.
 git clone https://github.com/SegFaulty/DocThor
 php -d extension=modules/zmq.so DocThor/DocThor.php --sourceDir=./ zmq
 ```
+
+## Windows Build Instructions (PHP 8.x)
+* `git clone https://github.com/Microsoft/php-sdk-binary-tools`
+* Open "Developer Command Prompt for VS2019" 
+* All commands listed below must be run using the VS2019 command prompt you just opened:
+* cd into the directory you just cloned, and run `phpsdk-vs16-x64.bat`
+* `phpsdk_buildtree phpdev`
+* Download source code of the PHP version you're building for: https://windows.php.net/download/
+* Extract the source code under `<php-sdk-binary-tools>/phpdev/vs16/x64/php-8.2.4-src` (replace php version with whatever version you downloaded)
+* Download libzmq: https://github.com/zeromq/libzmq/releases (eg. libzmq-v142-x64-4_3_4.zip)
+* Extract under `<php-sdk-binary-tools>/phpdev/vs16/x64/zmq`
+* In that folder, rename libzmq-v142-mt-4_3_4.lib to libzmq.lib
+* `cd <php-sdk-binary-tools>/phpdev/vs16/x64/php-8.2.4-src`
+* `buildconf`
+* `configure --with-zmq="<php-sdk-binary-tools>/phpdev/vs16/x64/zmq,shared"`
+* `nmake`

--- a/php_zmq_private.h
+++ b/php_zmq_private.h
@@ -45,7 +45,7 @@
 # endif
 #endif
 
-#ifdef PHP_WIN32
+#if (PHP_VERSION_ID < 80000) && defined(PHP_WIN32)
 # include "win32/php_stdint.h"
 #else
 # include <stdint.h>


### PR DESCRIPTION
- see https://github.com/php-amqp/php-amqp/issues/390
- https://github.com/zeromq/php-zmq/issues/223